### PR TITLE
Android 16.0: remove trout, cuttlefish, cuttlefish_vmm and cuttlefish_prebuilts

### DIFF
--- a/remove.xml
+++ b/remove.xml
@@ -6,6 +6,8 @@
   <remove-project name="device/google/common/etm" />
   <remove-project name="device/google/contexthub" />
   <remove-project name="device/google_car" />
+  <remove-project name="device/google/cuttlefish_prebuilts" />
+  <remove-project name="device/google/cuttlefish_vmm" />
   <remove-project name="device/linaro/dragonboard" />
   <remove-project name="device/linaro/dragonboard-kernel" />
   <remove-project name="device/linaro/hikey" />

--- a/remove.xml
+++ b/remove.xml
@@ -8,6 +8,8 @@
   <remove-project name="device/google_car" />
   <remove-project name="device/google/cuttlefish_prebuilts" />
   <remove-project name="device/google/cuttlefish_vmm" />
+  <remove-project name="device/google/cuttlefish" />
+  <remove-project name="device/google/trout" />
   <remove-project name="device/linaro/dragonboard" />
   <remove-project name="device/linaro/dragonboard-kernel" />
   <remove-project name="device/linaro/hikey" />


### PR DESCRIPTION
This PR removes the repos `device/google/cuttlefish_prebuilts`, `device/google/cuttlefish_vmm`, `device/google/cuttlefish` and `device/google/trout` because they cannot be checked out and therefore the build fails.